### PR TITLE
rank: Fix triggering infinite indexing

### DIFF
--- a/f/search/categories/rank_categories.py
+++ b/f/search/categories/rank_categories.py
@@ -7,7 +7,7 @@ import duckdb
 import wmill
 from sqlalchemy import Engine, text
 
-from f.utils.db.crdb import create_sql_engine
+from f.utils.db.crdb import create_sql_engine, filter_unchanged_ranks
 
 WEIGHTS = {
     "has_name_en": 0.30,
@@ -88,10 +88,17 @@ def main(keys: list[str]) -> dict[str, int]:
             "order": round(order, 4),
         }
 
-    with crdb.begin() as conn:
-        conn.execute(
-            text("UPDATE public.categories SET rank = :rank WHERE id = :id"),
-            [{"rank": json.dumps(r), "id": id_} for id_, r in ranks.items()],
-        )
+    # Filter to only include ranks that have changed
+    changed_ranks = filter_unchanged_ranks(crdb, "categories", ranks)
 
-    return {"updated": len(ranks)}
+    if changed_ranks:
+        with crdb.begin() as conn:
+            conn.execute(
+                text("UPDATE public.categories SET rank = :rank WHERE id = :id"),
+                [
+                    {"rank": json.dumps(r), "id": id_}
+                    for id_, r in changed_ranks.items()
+                ],
+            )
+
+    return {"updated": len(changed_ranks)}

--- a/f/search/components/rank_components.py
+++ b/f/search/components/rank_components.py
@@ -7,7 +7,7 @@ import duckdb
 import wmill
 from sqlalchemy import Engine, text
 
-from f.utils.db.crdb import create_sql_engine
+from f.utils.db.crdb import create_sql_engine, filter_unchanged_ranks
 from f.utils.general import llm_agent
 from f.context.llm_rank import compute_llm_hash, score_entity
 
@@ -135,10 +135,17 @@ def main(keys: list[str]) -> dict[str, int]:
             "order": round(order, 4),
         }
 
-    with crdb.begin() as conn:
-        conn.execute(
-            text("UPDATE public.components SET rank = :rank WHERE id = :id"),
-            [{"rank": json.dumps(r), "id": id_} for id_, r in ranks.items()],
-        )
+    # Filter to only include ranks that have changed
+    changed_ranks = filter_unchanged_ranks(crdb, "components", ranks)
 
-    return {"updated": len(ranks)}
+    if changed_ranks:
+        with crdb.begin() as conn:
+            conn.execute(
+                text("UPDATE public.components SET rank = :rank WHERE id = :id"),
+                [
+                    {"rank": json.dumps(r), "id": id_}
+                    for id_, r in changed_ranks.items()
+                ],
+            )
+
+    return {"updated": len(changed_ranks)}

--- a/f/search/items/rank_items.py
+++ b/f/search/items/rank_items.py
@@ -7,7 +7,7 @@ import duckdb
 import wmill
 from sqlalchemy import Engine, text
 
-from f.utils.db.crdb import create_sql_engine
+from f.utils.db.crdb import create_sql_engine, filter_unchanged_ranks
 from f.utils.general import llm_agent
 from f.context.llm_rank import compute_llm_hash, score_entity
 
@@ -138,10 +138,17 @@ def main(keys: list[str]) -> dict[str, int]:
             "order": round(order, 4),
         }
 
-    with crdb.begin() as conn:
-        conn.execute(
-            text("UPDATE public.items SET rank = :rank WHERE id = :id"),
-            [{"rank": json.dumps(r), "id": id_} for id_, r in ranks.items()],
-        )
+    # Filter to only include ranks that have changed
+    changed_ranks = filter_unchanged_ranks(crdb, "items", ranks)
 
-    return {"updated": len(ranks)}
+    if changed_ranks:
+        with crdb.begin() as conn:
+            conn.execute(
+                text("UPDATE public.items SET rank = :rank WHERE id = :id"),
+                [
+                    {"rank": json.dumps(r), "id": id_}
+                    for id_, r in changed_ranks.items()
+                ],
+            )
+
+    return {"updated": len(changed_ranks)}

--- a/f/search/orgs/rank_orgs.py
+++ b/f/search/orgs/rank_orgs.py
@@ -7,7 +7,7 @@ import duckdb
 import wmill
 from sqlalchemy import Engine, text
 
-from f.utils.db.crdb import create_sql_engine
+from f.utils.db.crdb import create_sql_engine, filter_unchanged_ranks
 from f.utils.general import llm_agent
 from f.context.llm_rank import compute_llm_hash, score_entity
 
@@ -135,10 +135,17 @@ def main(keys: list[str]) -> dict[str, int]:
             "order": round(order, 4),
         }
 
-    with crdb.begin() as conn:
-        conn.execute(
-            text("UPDATE public.orgs SET rank = :rank WHERE id = :id"),
-            [{"rank": json.dumps(r), "id": id_} for id_, r in ranks.items()],
-        )
+    # Filter to only include ranks that have changed
+    changed_ranks = filter_unchanged_ranks(crdb, "orgs", ranks)
 
-    return {"updated": len(ranks)}
+    if changed_ranks:
+        with crdb.begin() as conn:
+            conn.execute(
+                text("UPDATE public.orgs SET rank = :rank WHERE id = :id"),
+                [
+                    {"rank": json.dumps(r), "id": id_}
+                    for id_, r in changed_ranks.items()
+                ],
+            )
+
+    return {"updated": len(changed_ranks)}

--- a/f/search/places/rank_places.py
+++ b/f/search/places/rank_places.py
@@ -7,7 +7,7 @@ import duckdb
 import wmill
 from sqlalchemy import Engine, text
 
-from f.utils.db.crdb import create_sql_engine
+from f.utils.db.crdb import create_sql_engine, filter_unchanged_ranks
 from f.utils.general import llm_agent
 from f.context.llm_rank import compute_llm_hash, score_entity
 
@@ -135,10 +135,17 @@ def main(keys: list[str]) -> dict[str, int]:
             "order": round(order, 4),
         }
 
-    with crdb.begin() as conn:
-        conn.execute(
-            text("UPDATE public.places SET rank = :rank WHERE id = :id"),
-            [{"rank": json.dumps(r), "id": id_} for id_, r in ranks.items()],
-        )
+    # Filter to only include ranks that have changed
+    changed_ranks = filter_unchanged_ranks(crdb, "places", ranks)
 
-    return {"updated": len(ranks)}
+    if changed_ranks:
+        with crdb.begin() as conn:
+            conn.execute(
+                text("UPDATE public.places SET rank = :rank WHERE id = :id"),
+                [
+                    {"rank": json.dumps(r), "id": id_}
+                    for id_, r in changed_ranks.items()
+                ],
+            )
+
+    return {"updated": len(changed_ranks)}

--- a/f/search/processes/rank_processes.py
+++ b/f/search/processes/rank_processes.py
@@ -4,7 +4,7 @@ import json
 
 from sqlalchemy import Engine, text
 
-from f.utils.db.crdb import create_sql_engine
+from f.utils.db.crdb import create_sql_engine, filter_unchanged_ranks
 from f.utils.general import llm_agent
 from f.context.llm_rank import compute_llm_hash, score_entity
 
@@ -110,10 +110,17 @@ def main(keys: list[str]) -> dict[str, int]:
             "order": round(order, 4),
         }
 
-    with crdb.begin() as conn:
-        conn.execute(
-            text("UPDATE public.processes SET rank = :rank WHERE id = :id"),
-            [{"rank": json.dumps(r), "id": id_} for id_, r in ranks.items()],
-        )
+    # Filter to only include ranks that have changed
+    changed_ranks = filter_unchanged_ranks(crdb, "processes", ranks)
 
-    return {"updated": len(ranks)}
+    if changed_ranks:
+        with crdb.begin() as conn:
+            conn.execute(
+                text("UPDATE public.processes SET rank = :rank WHERE id = :id"),
+                [
+                    {"rank": json.dumps(r), "id": id_}
+                    for id_, r in changed_ranks.items()
+                ],
+            )
+
+    return {"updated": len(changed_ranks)}

--- a/f/search/programs/rank_programs.py
+++ b/f/search/programs/rank_programs.py
@@ -7,7 +7,7 @@ import duckdb
 import wmill
 from sqlalchemy import Engine, text
 
-from f.utils.db.crdb import create_sql_engine
+from f.utils.db.crdb import create_sql_engine, filter_unchanged_ranks
 from f.utils.general import llm_agent
 from f.context.llm_rank import compute_llm_hash, score_entity
 
@@ -135,10 +135,17 @@ def main(keys: list[str]) -> dict[str, int]:
             "order": round(order, 4),
         }
 
-    with crdb.begin() as conn:
-        conn.execute(
-            text("UPDATE public.programs SET rank = :rank WHERE id = :id"),
-            [{"rank": json.dumps(r), "id": id_} for id_, r in ranks.items()],
-        )
+    # Filter to only include ranks that have changed
+    changed_ranks = filter_unchanged_ranks(crdb, "programs", ranks)
 
-    return {"updated": len(ranks)}
+    if changed_ranks:
+        with crdb.begin() as conn:
+            conn.execute(
+                text("UPDATE public.programs SET rank = :rank WHERE id = :id"),
+                [
+                    {"rank": json.dumps(r), "id": id_}
+                    for id_, r in changed_ranks.items()
+                ],
+            )
+
+    return {"updated": len(changed_ranks)}

--- a/f/search/tags/rank_tags.py
+++ b/f/search/tags/rank_tags.py
@@ -5,7 +5,7 @@ import math
 
 from sqlalchemy import Engine, text
 
-from f.utils.db.crdb import create_sql_engine
+from f.utils.db.crdb import create_sql_engine, filter_unchanged_ranks
 
 WEIGHTS = {
     "has_name_en": 0.40,
@@ -83,10 +83,17 @@ def main(keys: list[str]) -> dict[str, int]:
             "order": round(order, 4),
         }
 
-    with crdb.begin() as conn:
-        conn.execute(
-            text("UPDATE public.tags SET rank = :rank WHERE id = :id"),
-            [{"rank": json.dumps(r), "id": id_} for id_, r in ranks.items()],
-        )
+    # Filter to only include ranks that have changed
+    changed_ranks = filter_unchanged_ranks(crdb, "tags", ranks)
 
-    return {"updated": len(ranks)}
+    if changed_ranks:
+        with crdb.begin() as conn:
+            conn.execute(
+                text("UPDATE public.tags SET rank = :rank WHERE id = :id"),
+                [
+                    {"rank": json.dumps(r), "id": id_}
+                    for id_, r in changed_ranks.items()
+                ],
+            )
+
+    return {"updated": len(changed_ranks)}

--- a/f/search/variants/rank_variants.py
+++ b/f/search/variants/rank_variants.py
@@ -7,7 +7,7 @@ import duckdb
 import wmill
 from sqlalchemy import Engine, text
 
-from f.utils.db.crdb import create_sql_engine
+from f.utils.db.crdb import create_sql_engine, filter_unchanged_ranks
 from f.utils.general import llm_agent
 from f.context.llm_rank import compute_llm_hash, score_entity
 
@@ -143,10 +143,17 @@ def main(keys: list[str]) -> dict[str, int]:
             "order": round(order, 4),
         }
 
-    with crdb.begin() as conn:
-        conn.execute(
-            text("UPDATE public.variants SET rank = :rank WHERE id = :id"),
-            [{"rank": json.dumps(r), "id": id_} for id_, r in ranks.items()],
-        )
+    # Filter to only include ranks that have changed
+    changed_ranks = filter_unchanged_ranks(crdb, "variants", ranks)
 
-    return {"updated": len(ranks)}
+    if changed_ranks:
+        with crdb.begin() as conn:
+            conn.execute(
+                text("UPDATE public.variants SET rank = :rank WHERE id = :id"),
+                [
+                    {"rank": json.dumps(r), "id": id_}
+                    for id_, r in changed_ranks.items()
+                ],
+            )
+
+    return {"updated": len(changed_ranks)}

--- a/f/utils/db/crdb.py
+++ b/f/utils/db/crdb.py
@@ -153,6 +153,47 @@ def load_tags_by_entity_ids(
     return tags_by_entity
 
 
+def filter_unchanged_ranks(
+    crdb: Engine,
+    table: str,
+    new_ranks: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """
+    Filter out ranks that haven't changed to avoid triggering unnecessary changefeed events.
+
+    Args:
+        crdb: SQLAlchemy Engine for database connection
+        table: Table name to query existing ranks from
+        new_ranks: Dictionary mapping id -> rank dict with new computed values
+
+    Returns:
+        Dictionary containing only the ranks that have changed
+    """
+    if not new_ranks:
+        return {}
+
+    ids = list(new_ranks.keys())
+    ids_join = "','".join(ids)
+
+    existing_ranks: dict[str, str | None] = {}
+    with crdb.connect() as conn:
+        rows = conn.execute(
+            text(f"SELECT id, rank FROM public.{table} WHERE id IN ('{ids_join}')")
+        ).fetchall()
+        existing_ranks = {str(row[0]): row[1] for row in rows}
+
+    changed_ranks = {}
+    for id_, new_rank in new_ranks.items():
+        existing_rank_json = existing_ranks.get(id_)
+        new_rank_json = json.dumps(new_rank)
+
+        # Only include if rank doesn't exist or has changed
+        if existing_rank_json is None or existing_rank_json != new_rank_json:
+            changed_ranks[id_] = new_rank
+
+    return changed_ranks
+
+
 def db_write_dataframe(
     df: pl.DataFrame | pl.LazyFrame,
     table: str,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevented changefeed loops by updating `rank` only when values actually change. This stops infinite re-indexing and cuts unnecessary DB writes.

- **Bug Fixes**
  - Added `filter_unchanged_ranks(crdb, table, new_ranks)` in `f/utils/db/crdb.py` to compare new ranks with existing values.
  - Updated rank jobs for `categories`, `components`, `items`, `orgs`, `places`, `processes`, `programs`, `tags`, and `variants` to use the helper, guard updates, and return accurate update counts.
  - Reduces changefeed churn and avoids triggering infinite indexing when ranks are unchanged.

<sup>Written for commit b3a5b119653828fc65ed2e6063dcad47ed820f7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/databot/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

