### PR TITLE
index: Fix rank diff detection

### DIFF
--- a/f/utils/db/crdb.py
+++ b/f/utils/db/crdb.py
@@ -175,23 +175,20 @@ def filter_unchanged_ranks(
     ids = list(new_ranks.keys())
     ids_join = "','".join(ids)
 
-    existing_ranks: dict[str, str | None] = {}
+    existing_ranks: dict[str, Any] = {}
     with crdb.connect() as conn:
         rows = conn.execute(
             text(f"SELECT id, rank FROM public.{table} WHERE id IN ('{ids_join}')")
         ).fetchall()
-        existing_ranks = {str(row[0]): row[1] for row in rows}
+        for row in rows:
+            rank_value = row[1]
+            if isinstance(rank_value, str):
+                rank_value = json.loads(rank_value)
+            existing_ranks[str(row[0])] = rank_value
 
-    changed_ranks = {}
-    for id_, new_rank in new_ranks.items():
-        existing_rank_json = existing_ranks.get(id_)
-        new_rank_json = json.dumps(new_rank)
-
-        # Only include if rank doesn't exist or has changed
-        if existing_rank_json is None or existing_rank_json != new_rank_json:
-            changed_ranks[id_] = new_rank
-
-    return changed_ranks
+    return {
+        id_: rank for id_, rank in new_ranks.items() if existing_ranks.get(id_) != rank
+    }
 
 
 def db_write_dataframe(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix rank change detection by decoding stored JSON ranks and comparing structured values. Prevents missed updates and unnecessary writes.

- **Bug Fixes**
  - Parse DB `rank` strings with `json.loads` before comparison.
  - Compare objects directly instead of JSON strings.
  - Simplify logic to return only IDs with changed ranks.

<sup>Written for commit ebadfc35ba720e9703b32c909f5f2cd646d6d189. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/databot/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

